### PR TITLE
feat: Add key Regards

### DIFF
--- a/src/pt_BR.json
+++ b/src/pt_BR.json
@@ -109,6 +109,7 @@
   "Profile Information": "Informação do Perfil",
   "Recovery Code": "Código Recuperado",
   "Regards,": "Saudações,",
+  "Regards": "Saudações",
   "Regenerate Recovery Codes": "Gerar novamente os códigos de recuperação",
   "Register": "Registre-se",
   "Sign up": "Registrar-se",


### PR DESCRIPTION
Para as versões 10 do Laravel e anteriores a key para Regards não tinham vírgula, sendo "Regards", foi mantida a com vírgula  "Regards," usada na versão 11 em diante.